### PR TITLE
Export shortcuts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 /gtrace
 /pinger
 /buildtags

--- a/cmd/gtrace/main.go
+++ b/cmd/gtrace/main.go
@@ -302,6 +302,9 @@ func main() {
 	for i, item := range items {
 		t := p.Traces[i]
 		for _, field := range item.StructType.Fields.List {
+			if _, ok := field.Type.(*ast.FuncType); !ok {
+				continue
+			}
 			name := field.Names[0].Name
 			fn, ok := field.Type.(*ast.FuncType)
 			if !ok {

--- a/cmd/gtrace/main.go
+++ b/cmd/gtrace/main.go
@@ -489,6 +489,7 @@ func (f GenFlag) Has(x GenFlag) bool {
 const (
 	GenZero GenFlag = 1 << iota >> 1
 	GenShortcut
+	GenShortcutPublic
 	GenContext
 
 	GenAll = ^GenFlag(0)
@@ -527,6 +528,8 @@ func (g *GenConfig) ParseParameter(text string) (err error) {
 	switch param {
 	case "shortcut":
 		g.Flag |= GenShortcut
+	case "Shortcut", "SHORTCUT":
+		g.Flag |= GenShortcutPublic
 	case "context":
 		g.Flag |= GenContext
 	default:


### PR DESCRIPTION
Shortcuts helps to check nil trace callbacks. But current private shortcuts cannot be use outside from package with trace.
This PR make optionally creation of shortcuts as public from trace package